### PR TITLE
Add events module as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
   },
   "dependencies": {
     "buffer": "5.0.x",
+    "events": "1.1.x",
     "sax": "0.6.x",
     "stream": "0.0.x",
     "timers": "0.1.x",


### PR DESCRIPTION
Hi, I've found when using the module that 'events' is required as a dependency of xml2js also.  Without it I get the error "Unable to resolve module events" in my build.

react-native-cli: 2.0.1
react-native: 0.41.2

I'm not sure why this hasn't caught out anyone else before now, so I might be wrong.  But I'm assuming that 'events' is quite a common dependency of other modules, so it's gone unnoticed.

Cheers